### PR TITLE
refactor: scope configuration under "extensions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ filters:
 Configure which elements should show colour previews:
 
 ```yaml
-preview-colour:
-  code: true   # Enable previews for inline code
-  text: true   # Enable previews for regular text
+extensions:
+  preview-colour:
+    code: true   # Enable previews for inline code
+    text: false   # Enable previews for regular text
 ```
 
 ## Supported Colour Formats

--- a/example.qmd
+++ b/example.qmd
@@ -49,9 +49,15 @@ embed-resources: true
 engine: markdown
 filters:
   - preview-colour
-preview-colour:
-  code: true
-  text: true
+# Deprecated configuration (will show warning):
+# preview-colour:
+#   code: true
+#   text: true
+# New recommended configuration:
+extensions:
+  preview-colour:
+    code: true
+    text: true
 ---
 
 ## Usage


### PR DESCRIPTION
Update the configuration for the preview-colour extension to a nested structure under `extensions`. Deprecate the top-level configuration and provide a warning for users to transition to the new format. Adjust the code to support both the new and deprecated configurations.