### PR TITLE
feat: add Typst support for colour previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ filters:
   - preview-colour
 ```
 
+````qmd
+- code: `#441100` or `rgb(10, 100, 200)`
+- text: #441100 or rgb(10,100,200)
+````
+
 ### Configuration Options
 
 Configure which elements should show colour previews:

--- a/_extensions/preview-colour/preview-colour.lua
+++ b/_extensions/preview-colour/preview-colour.lua
@@ -227,6 +227,15 @@ function escape_latex(text)
   return text
 end
 
+--- Escape special Typst characters in text.
+--- @param text string The text to escape
+--- @return string The escaped text safe for Typst
+function escape_typst(text)
+  -- Escape special Typst characters
+  text = string.gsub(text, "%#", "\\#")
+  return text
+end
+
 --- Escape special Lua pattern characters for use in string.gsub.
 --- @param text string The text containing characters to escape
 --- @return string The escaped text safe for Lua patterns
@@ -360,6 +369,18 @@ function process_str(element, meta)
           escaped_replacement
         )
         return pandoc.RawInline('latex', new_text)
+      elseif quarto.doc.is_format("typst") then
+        local hex_colour_six = expand_hex_colour(hex)
+        local colour_preview_mark = "#text(fill: rgb(\"" .. string.lower(hex_colour_six) .. "\"))[◉]"
+        local escaped_original = escape_typst(original_colour_text)
+        local escaped_pattern = escape_lua_pattern(original_colour_text)
+        local escaped_replacement = string.gsub(escaped_original, "%%", "%%%%") .. colour_preview_mark
+        local new_text = string.gsub(
+          element.text,
+          escaped_pattern,
+          escaped_replacement
+        )
+        return pandoc.RawInline('typst', new_text)
       end
     end
   end
@@ -382,6 +403,10 @@ function process_code(element)
         local hex_colour_six = expand_hex_colour(hex)
         local colour_preview_mark = "\\textcolor[HTML]{" .. string.gsub(hex_colour_six, '#', '') .. "}{\\textbullet}"
         return pandoc.Span({element, pandoc.RawInline('latex', colour_preview_mark)})
+      elseif quarto.doc.is_format("typst") then
+        local hex_colour_six = expand_hex_colour(hex)
+        local colour_preview_mark = "#text(fill: rgb(\"" .. string.lower(hex_colour_six) .. "\"))[◉]"
+        return pandoc.Span({element, pandoc.RawInline('typst', colour_preview_mark)})
       end
     end
   end

--- a/example.qmd
+++ b/example.qmd
@@ -3,12 +3,12 @@ title: "preview-colour Example"
 format:
   html:
     output-file: index
-  # typst:
-  #   output-file: preview-colour-typst
-  #   papersize: a4
-  #   margin:
-  #     x: 2.5cm
-  #     y: 2.5cm
+  typst:
+    output-file: preview-colour-typst
+    papersize: a4
+    margin:
+      x: 2.5cm
+      y: 2.5cm
   pdf-xelatex:
     output-file: preview-colour-xelatex
     papersize: a4
@@ -36,7 +36,7 @@ format:
     aspectratio: 169
 format-links:
   - html
-  # - typst
+  - typst
   - format: pdf-xelatex
     text: "PDF (XeLaTeX)"
   - format: pdf-lualatex
@@ -60,24 +60,7 @@ extensions:
     text: true
 ---
 
-## Usage
-
-The `#b22222` colour is a dark red colour, also known as firebrick.
-It is a web safe colour.
-
-::: {.content-visible when-format="html"}
-The #b22 colour hex could be obtained by blending #ff4444 with #640000.
-Closest websafe colour is: #cc3333.
-:::
-
-```r
-my_colour <- "#b22222"
-```
-
-`rgb(10, 100, 200)` or `rgb(10,100,200)` is a blue colour and `hsl(240, 100%, 50%)` is a colour too.  
-But it does not work with rgb(10,100,200) and hsl(240,100%,50%).
-
-## Supported inline code syntax
+## Supported Colour Formats
 
 - [ ] Names one: `orange` (*will probably never be supported*)
 - [x] hex codes:


### PR DESCRIPTION
Introduce functionality to escape special Typst characters and process colour previews in Typst format.