### PR TITLE
feat: add support for DOCX and PPTX formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.log
 *.aux
 *.tex
+*.docx
+*.pptx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Preview Colour Extension For Quarto
 
-`preview-colour` is a [Quarto](https://quarto.org) extension that automatically renders colour previews for inline colour codes in both code blocks and regular text. It supports multiple colour formats including hex, RGB, HSL, and HWB values.
+`preview-colour` is a [Quarto](https://quarto.org) extension that automatically renders colour previews for inline colour codes in both code blocks and regular text.
+It supports multiple colour formats including hex, RGB, HSL, and HWB values.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -81,3 +81,5 @@ Outputs of `example.qmd`:
 - [LaTeX/PDF (PDFLaTeX)](https://m.canouil.dev/quarto-preview-colour-text/preview-colour-pdflatex.pdf)
 - [Reveal.js](https://m.canouil.dev/quarto-preview-colour-text/preview-colour-revealjs.html)
 - [Beamer/PDF](https://m.canouil.dev/quarto-preview-colour-text/preview-colour-beamer.pdf)
+- [Word/Docx](https://m.canouil.dev/quarto-highlight-text/highlight-openxml.docx)
+- [PowerPoint/Pptx](https://m.canouil.dev/quarto-highlight-text/highlight-pptx.pptx)

--- a/example.qmd
+++ b/example.qmd
@@ -1,5 +1,5 @@
 ---
-title: "preview-colour Example"
+title: "Preview Colour Example"
 format:
   html:
     output-file: index
@@ -31,9 +31,14 @@ format:
       y: 2.5cm
   revealjs:
     output-file: preview-colour-revealjs
+    shift-heading-level-by: -1
   beamer:
     output-file: preview-colour-beamer
     aspectratio: 169
+  docx:
+    output-file: preview-colour-docx
+  pptx:
+    output-file: preview-colour-pptx
 format-links:
   - html
   - typst
@@ -45,6 +50,8 @@ format-links:
     text: "PDF (PDFLaTeX)"
   - revealjs
   - beamer
+  - docx
+  - pptx
 embed-resources: true
 engine: markdown
 filters:
@@ -62,28 +69,42 @@ extensions:
 
 ## Supported Colour Formats
 
-- ❌ Names one: `orange` (*will probably never be supported*)
-- ✅ hex codes:
-  - ✅ **code**: `#441100`
-  - ✅ **text**: #441100
-- ✅ short hex codes:
-  - ✅ **code**: `#F03`
-  - ✅ **text**: #F03
-- 🔶 rgb:
-  - ✅ **code**: `rgb(10, 100, 200)`
-  - ✅ **code** (no space): `rgb(10,100,200)`
-  - ❌ **text**: rgb(10, 100, 200)
-  - ✅ **text** (no space): rgb(10,100,200)
-- 🔶 rgb with %:
-  - ✅ **code**: `rgb(100%, 20%, 100%)`
-  - ✅ **code** (no space): `rgb(100%,20%,100%)`
-  - ❌ **text**: rgb(100%, 20%, 100%)
-  - ✅ **text** (no space): rgb(100%,20%,100%)
-- 🔶 hwb:
-  - ✅ **code**: `hwb(135 0% 40%)`
-  - ❌ **text**: hwb(135 0% 40%)
-- 🔶 hsl:
-  - ✅ **code**: `hsl(240, 100%, 50%)`
-  - ✅ **code** (no space): `hsl(240,100%,50%)`
-  - ❌ **text**: hsl(240, 100%, 50%)
-  - ✅ **text** (no space): hsl(240,100%,50%)
+### ❌ Names
+
+- Names one: `orange` (*will probably never be supported*)
+
+### ✅ Hex Codes
+
+- ✅ **code**: `#441100`
+- ✅ **text**: #441100
+
+### ✅ short hex codes
+
+- ✅ **code**: `#F03`
+- ✅ **text**: #F03
+
+### 🔶 RGB
+
+- ✅ **code**: `rgb(10, 100, 200)`
+- ✅ **code** (no space): `rgb(10,100,200)`
+- ❌ **text**: rgb(10, 100, 200)
+- ✅ **text** (no space): rgb(10,100,200)
+
+### 🔶 RGB (%)
+
+- ✅ **code**: `rgb(100%, 20%, 100%)`
+- ✅ **code** (no space): `rgb(100%,20%,100%)`
+- ❌ **text**: rgb(100%, 20%, 100%)
+- ✅ **text** (no space): rgb(100%,20%,100%)
+
+### 🔶 HWB
+
+- ✅ **code**: `hwb(135 0% 40%)`
+- ❌ **text**: hwb(135 0% 40%)
+
+### 🔶 HSL
+
+- ✅ **code**: `hsl(240, 100%, 50%)`
+- ✅ **code** (no space): `hsl(240,100%,50%)`
+- ❌ **text**: hsl(240, 100%, 50%)
+- ✅ **text** (no space): hsl(240,100%,50%)


### PR DESCRIPTION
Introduce functionality to generate colour previews in DOCX and PPTX formats, enhancing the extension's compatibility with Microsoft Office documents. Update documentation to reflect these new output options.