### PR TITLE
fix: honour boolean false and stop the deprecated form crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Honour `code: false` and `text: false`. A bare YAML `false` was read as an absent option, so the feature stayed on at its default, and no spelling of the value worked.
+- fix: Stop the deprecated top-level `preview-colour:` block failing the render. A document configured that way and carrying no `extensions:` key was warned about the deprecation and then died with `attempt to index a nil value (field 'extensions')`.
+
 ### Documentation
 
 - docs: Add a documentation website under `docs/`, built on the `atelier` project type and published to <https://m.canouil.dev/quarto-preview-colour/>.

--- a/_extensions/preview-colour/_modules/metadata.lua
+++ b/_extensions/preview-colour/_modules/metadata.lua
@@ -1,5 +1,5 @@
 --- MC Metadata - Extension configuration and metadata access for Quarto Lua filters and shortcodes
---- @module metadata
+--- @module "metadata"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
@@ -42,8 +42,12 @@ end
 --- @param key string The metadata key to retrieve
 --- @return string|nil The metadata value as a string, or nil if not found
 --- @usage local repo = M.get_metadata_value(meta, "github", "repository-name")
+--- @note A boolean `false` is a value, not an absence, so the test is against
+---   `nil` rather than truthiness. Stringifying it yields "false", which is what
+---   a caller comparing against the string form already expects.
 function M.get_metadata_value(meta, extension_name, key)
-  if meta['extensions'] and meta['extensions'][extension_name] and meta['extensions'][extension_name][key] then
+  if meta['extensions'] and meta['extensions'][extension_name]
+      and meta['extensions'][extension_name][key] ~= nil then
     return str.stringify(meta['extensions'][extension_name][key])
   end
   return nil
@@ -173,6 +177,44 @@ function M.get_options(spec)
   end
 
   return result
+end
+
+-- ============================================================================
+-- PROJECT METADATA UTILITIES
+-- ============================================================================
+
+--- Get repo-url from Quarto project metadata via QUARTO_EXECUTE_INFO.
+--- Reads the JSON file pointed to by the QUARTO_EXECUTE_INFO environment variable
+--- and extracts repo-url from website or book metadata.
+--- @return string|nil The repo-url value, or nil if not available
+function M.get_project_repo_url()
+  local path = os.getenv("QUARTO_EXECUTE_INFO")
+  if not path then return nil end
+
+  local file = io.open(path, "r")
+  if not file then return nil end
+
+  local content = file:read("*a")
+  file:close()
+
+  if str.is_empty(content) then return nil end
+
+  local ok, info = pcall(quarto.json.decode, content)
+  if not ok or not info then return nil end
+
+  local format_meta = info["format"] and info["format"]["metadata"]
+  if not format_meta then return nil end
+
+  -- Try website.repo-url first, then book.repo-url
+  local repo_url = nil
+  if format_meta["website"] and format_meta["website"]["repo-url"] then
+    repo_url = format_meta["website"]["repo-url"]
+  elseif format_meta["book"] and format_meta["book"]["repo-url"] then
+    repo_url = format_meta["book"]["repo-url"]
+  end
+
+  if str.is_empty(repo_url) then return nil end
+  return repo_url
 end
 
 -- ============================================================================

--- a/_extensions/preview-colour/preview-colour.lua
+++ b/_extensions/preview-colour/preview-colour.lua
@@ -146,16 +146,19 @@ end
 --- @param meta table<string, any> Document metadata table.
 --- @return boolean The option value as a boolean.
 local function get_preview_colour_option(key, meta)
+  -- Both sources hand back a string, and the callers compare against a boolean,
+  -- so coerce here rather than leaving the type to depend on where the value
+  -- came from.
   -- Check new nested structure: extensions.preview-colour.key
   local meta_value = meta_mod.get_metadata_value(meta, 'preview-colour', key)
   if not str.is_empty(meta_value) then
-    return meta_value
+    return meta_value:lower() ~= 'false'
   end
 
   -- Check deprecated top-level structure: preview-colour.key (with warning)
   local deprecated_value = check_deprecated_config(meta, key)
   if deprecated_value ~= nil then
-    return deprecated_value
+    return tostring(deprecated_value):lower() ~= 'false'
   end
 
   -- Return default values: code: true, text: false
@@ -728,6 +731,12 @@ local function get_colour_preview_meta(meta)
     else
       json_export_file = json_value
     end
+  end
+
+  -- A document configured only through the deprecated top-level block has no
+  -- `extensions` key at all, so the table has to exist before writing into it.
+  if meta['extensions'] == nil then
+    meta['extensions'] = {}
   end
 
   meta['extensions']['preview-colour'] = {


### PR DESCRIPTION
`get_metadata_value` guarded on truthiness, so `code: false` was read as an absent option and the feature stayed on at its default. Quoting the value did not help: the callers compared against a boolean while the accessor returns a string, so the option had no working spelling. The shared module now tests for `nil`, and the option reader coerces both sources to a boolean.

Separately, a document using the deprecated top-level `preview-colour:` block and carrying no `extensions:` key was warned about the deprecation and then failed the render, because the filter wrote into `meta['extensions']` without creating it first.

Verified by rendering three documents before and after: `code: false` under `extensions:` (1 swatch before, 0 after), the deprecated top-level form (crash before, renders and honours the option after), and no configuration at all (1 swatch both, no regression).