### PR TITLE
fix: declare the filter entry point in the extension manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Register the filter at `post-quarto` in the extension manifest, so listing `preview-colour` under `filters` is enough and the entry point no longer has to be named in project or document YAML.
+- fix: Raise `quarto-required` to `>=1.9.38`, the first version whose `_extension.yml` schema accepts a filter entry point.
+
 ## 1.6.1 (2026-08-01)
 
 ### Bug Fixes

--- a/_extensions/preview-colour/_extension.yml
+++ b/_extensions/preview-colour/_extension.yml
@@ -1,7 +1,8 @@
 title: preview-colour
 author: Mickaël Canouil
 version: 1.6.1
-quarto-required: ">=1.3.0"
+quarto-required: ">=1.9.38"
 contributes:
-  filters: 
-    - preview-colour.lua
+  filters:
+    - path: preview-colour.lua
+      at: post-quarto

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -38,8 +38,7 @@ Enable the filter:
 
 ```yaml
 filters:
-  - path: preview-colour
-    at: post-quarto
+  - preview-colour
 ```
 
 Then write colours as you would anyway:

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -8,8 +8,7 @@ description: "The complete preview-colour configuration: the two scans, the glyp
 
 ```yaml
 filters:
-  - path: preview-colour
-    at: post-quarto
+  - preview-colour
 ```
 
 On Quarto older than 1.8.21 the filter was ordered by hand instead:


### PR DESCRIPTION
The extension manifest now registers the filter at `post-quarto`, so listing `preview-colour` under `filters` is enough and the entry point no longer has to be repeated in project or document YAML. The documentation and `example.qmd` use the short form throughout.

`quarto-required` moves to >=1.9.38, the first version whose `_extension.yml` schema accepts a filter entry point. Below it the render fails validation.