### PR TITLE
ci: pin the reusable workflows at v1

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   pages:
-    uses: mcanouil/quarto-workflows/.github/workflows/pages.yml@main
+    uses: mcanouil/quarto-workflows/.github/workflows/pages.yml@v1
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/quarto-extensions-updates.yml
+++ b/.github/workflows/quarto-extensions-updates.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   updates:
-    uses: mcanouil/quarto-workflows/.github/workflows/quarto-extensions-updates.yml@main
+    uses: mcanouil/quarto-workflows/.github/workflows/quarto-extensions-updates.yml@v1
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   release:
-    uses: mcanouil/quarto-workflows/.github/workflows/release.yml@main
+    uses: mcanouil/quarto-workflows/.github/workflows/release.yml@v1
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Points the reusable workflow calls at the v1 tag instead of main, so this repository runs a released version of mcanouil/quarto-workflows rather than tracking its default branch.